### PR TITLE
Update int types.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ bin/libkernel.a
 bin/kernel.bin
 bin/librlibc.rlib
 rustlibdir
+*.deflate

--- a/arch/x86/cpu/gdt.rs
+++ b/arch/x86/cpu/gdt.rs
@@ -6,7 +6,7 @@
 
 use core::marker::Copy;
 
-const GDT_COUNT: uint = 5;
+const GDT_COUNT: usize = 5;
 static mut gdt_entries: [GDTEntry; GDT_COUNT] = [GDTEntry { limit_low: 0, base_low: 0, base_middle: 0, access: 0, granularity: 0, base_high: 0 }; GDT_COUNT];
 static mut gdt_ptr: GDTPointer = GDTPointer { limit: 0, base: 0 };
 
@@ -27,7 +27,7 @@ impl Copy for GDTEntry {}
 struct GDTPointer
 {
 	limit: u16,
-	base: u32
+	base: usize
 }
 
 pub fn init_gdt()
@@ -35,7 +35,7 @@ pub fn init_gdt()
 	unsafe
 	{
 		gdt_ptr.limit = (::core::mem::size_of::<GDTEntry>() * GDT_COUNT - 1) as u16;
-		gdt_ptr.base = &gdt_entries as *const [GDTEntry; GDT_COUNT] as u32;
+		gdt_ptr.base = &gdt_entries as *const [GDTEntry; GDT_COUNT] as usize;
 
 		gdt_set_gate(0, 0, 0, 0, 0);
 		gdt_set_gate(1, 0, 0xFFFFFFFF, 0x9A, 0xCF);
@@ -43,11 +43,11 @@ pub fn init_gdt()
 		gdt_set_gate(3, 0, 0xFFFFFFFF, 0xFA, 0xCF);
 		gdt_set_gate(4, 0, 0xFFFFFFFF, 0xF2, 0xCF);
 
-		gdt_flush(&gdt_ptr as *const GDTPointer as u32);
+		gdt_flush(&gdt_ptr as *const GDTPointer as usize);
 	};
 }
 
-unsafe fn gdt_set_gate(n: uint, base: u32, limit: u32, access: u8, gran: u8)
+unsafe fn gdt_set_gate(n: usize, base: usize, limit: usize, access: u8, gran: u8)
 {
 	gdt_entries[n].base_low = (base & 0xFFFF) as u16;
 	gdt_entries[n].base_middle = ((base >> 16) & 0xFF) as u8;
@@ -62,5 +62,5 @@ unsafe fn gdt_set_gate(n: uint, base: u32, limit: u32, access: u8, gran: u8)
 
 extern
 {
-	fn gdt_flush(pointer: u32);
+	fn gdt_flush(pointer: usize);
 }

--- a/arch/x86/cpu/idt.rs
+++ b/arch/x86/cpu/idt.rs
@@ -6,7 +6,7 @@
 
 use core::marker::Copy;
 
-const IDT_COUNT: uint = 256;
+const IDT_COUNT: usize = 256;
 static mut idt_entries: [IDTEntry; IDT_COUNT] = [IDTEntry { base_low: 0, selector: 0, zero: 0, flags: 0, base_high: 0 }; IDT_COUNT];
 static mut idt_ptr: IDTPointer = IDTPointer { limit: 0, base: 0 };
 
@@ -26,7 +26,7 @@ impl Copy for IDTEntry {}
 struct IDTPointer
 {
 	limit: u16,
-	base: u32
+	base: usize
 }
 
 pub fn init_idt()
@@ -34,62 +34,62 @@ pub fn init_idt()
 	unsafe
 	{
 		idt_ptr.limit = (::core::mem::size_of::<IDTEntry>() * IDT_COUNT - 1) as u16;
-		idt_ptr.base = &idt_entries as *const [IDTEntry; IDT_COUNT] as u32;
+		idt_ptr.base = &idt_entries as *const [IDTEntry; IDT_COUNT] as usize;
 
-		idt_set_gate( 0, isr0  as u32, 0x08, 0x8E);
-		idt_set_gate( 1, isr1  as u32, 0x08, 0x8E);
-		idt_set_gate( 2, isr2  as u32, 0x08, 0x8E);
-		idt_set_gate( 3, isr3  as u32, 0x08, 0x8E);
-		idt_set_gate( 4, isr4  as u32, 0x08, 0x8E);
-		idt_set_gate( 5, isr5  as u32, 0x08, 0x8E);
-		idt_set_gate( 6, isr6  as u32, 0x08, 0x8E);
-		idt_set_gate( 7, isr7  as u32, 0x08, 0x8E);
-		idt_set_gate( 8, isr8  as u32, 0x08, 0x8E);
-		idt_set_gate( 9, isr9  as u32, 0x08, 0x8E);
-		idt_set_gate(10, isr10 as u32, 0x08, 0x8E);
-		idt_set_gate(11, isr11 as u32, 0x08, 0x8E);
-		idt_set_gate(12, isr12 as u32, 0x08, 0x8E);
-		idt_set_gate(13, isr13 as u32, 0x08, 0x8E);
-		idt_set_gate(14, isr14 as u32, 0x08, 0x8E);
-		idt_set_gate(15, isr15 as u32, 0x08, 0x8E);
-		idt_set_gate(16, isr16 as u32, 0x08, 0x8E);
-		idt_set_gate(17, isr17 as u32, 0x08, 0x8E);
-		idt_set_gate(18, isr18 as u32, 0x08, 0x8E);
-		idt_set_gate(19, isr19 as u32, 0x08, 0x8E);
-		idt_set_gate(20, isr20 as u32, 0x08, 0x8E);
-		idt_set_gate(21, isr21 as u32, 0x08, 0x8E);
-		idt_set_gate(22, isr22 as u32, 0x08, 0x8E);
-		idt_set_gate(23, isr23 as u32, 0x08, 0x8E);
-		idt_set_gate(24, isr24 as u32, 0x08, 0x8E);
-		idt_set_gate(25, isr25 as u32, 0x08, 0x8E);
-		idt_set_gate(26, isr26 as u32, 0x08, 0x8E);
-		idt_set_gate(27, isr27 as u32, 0x08, 0x8E);
-		idt_set_gate(28, isr28 as u32, 0x08, 0x8E);
-		idt_set_gate(29, isr29 as u32, 0x08, 0x8E);
-		idt_set_gate(30, isr30 as u32, 0x08, 0x8E);
-		idt_set_gate(31, isr31 as u32, 0x08, 0x8E);
-		idt_set_gate(32, irq0  as u32, 0x08, 0x8E);
-		idt_set_gate(33, irq1  as u32, 0x08, 0x8E);
-		idt_set_gate(34, irq2  as u32, 0x08, 0x8E);
-		idt_set_gate(35, irq3  as u32, 0x08, 0x8E);
-		idt_set_gate(36, irq4  as u32, 0x08, 0x8E);
-		idt_set_gate(37, irq5  as u32, 0x08, 0x8E);
-		idt_set_gate(38, irq6  as u32, 0x08, 0x8E);
-		idt_set_gate(39, irq7  as u32, 0x08, 0x8E);
-		idt_set_gate(40, irq8  as u32, 0x08, 0x8E);
-		idt_set_gate(41, irq9  as u32, 0x08, 0x8E);
-		idt_set_gate(42, irq10 as u32, 0x08, 0x8E);
-		idt_set_gate(43, irq11 as u32, 0x08, 0x8E);
-		idt_set_gate(44, irq12 as u32, 0x08, 0x8E);
-		idt_set_gate(45, irq13 as u32, 0x08, 0x8E);
-		idt_set_gate(46, irq14 as u32, 0x08, 0x8E);
-		idt_set_gate(47, irq15 as u32, 0x08, 0x8E);
+		idt_set_gate( 0, isr0  as usize, 0x08, 0x8E);
+		idt_set_gate( 1, isr1  as usize, 0x08, 0x8E);
+		idt_set_gate( 2, isr2  as usize, 0x08, 0x8E);
+		idt_set_gate( 3, isr3  as usize, 0x08, 0x8E);
+		idt_set_gate( 4, isr4  as usize, 0x08, 0x8E);
+		idt_set_gate( 5, isr5  as usize, 0x08, 0x8E);
+		idt_set_gate( 6, isr6  as usize, 0x08, 0x8E);
+		idt_set_gate( 7, isr7  as usize, 0x08, 0x8E);
+		idt_set_gate( 8, isr8  as usize, 0x08, 0x8E);
+		idt_set_gate( 9, isr9  as usize, 0x08, 0x8E);
+		idt_set_gate(10, isr10 as usize, 0x08, 0x8E);
+		idt_set_gate(11, isr11 as usize, 0x08, 0x8E);
+		idt_set_gate(12, isr12 as usize, 0x08, 0x8E);
+		idt_set_gate(13, isr13 as usize, 0x08, 0x8E);
+		idt_set_gate(14, isr14 as usize, 0x08, 0x8E);
+		idt_set_gate(15, isr15 as usize, 0x08, 0x8E);
+		idt_set_gate(16, isr16 as usize, 0x08, 0x8E);
+		idt_set_gate(17, isr17 as usize, 0x08, 0x8E);
+		idt_set_gate(18, isr18 as usize, 0x08, 0x8E);
+		idt_set_gate(19, isr19 as usize, 0x08, 0x8E);
+		idt_set_gate(20, isr20 as usize, 0x08, 0x8E);
+		idt_set_gate(21, isr21 as usize, 0x08, 0x8E);
+		idt_set_gate(22, isr22 as usize, 0x08, 0x8E);
+		idt_set_gate(23, isr23 as usize, 0x08, 0x8E);
+		idt_set_gate(24, isr24 as usize, 0x08, 0x8E);
+		idt_set_gate(25, isr25 as usize, 0x08, 0x8E);
+		idt_set_gate(26, isr26 as usize, 0x08, 0x8E);
+		idt_set_gate(27, isr27 as usize, 0x08, 0x8E);
+		idt_set_gate(28, isr28 as usize, 0x08, 0x8E);
+		idt_set_gate(29, isr29 as usize, 0x08, 0x8E);
+		idt_set_gate(30, isr30 as usize, 0x08, 0x8E);
+		idt_set_gate(31, isr31 as usize, 0x08, 0x8E);
+		idt_set_gate(32, irq0  as usize, 0x08, 0x8E);
+		idt_set_gate(33, irq1  as usize, 0x08, 0x8E);
+		idt_set_gate(34, irq2  as usize, 0x08, 0x8E);
+		idt_set_gate(35, irq3  as usize, 0x08, 0x8E);
+		idt_set_gate(36, irq4  as usize, 0x08, 0x8E);
+		idt_set_gate(37, irq5  as usize, 0x08, 0x8E);
+		idt_set_gate(38, irq6  as usize, 0x08, 0x8E);
+		idt_set_gate(39, irq7  as usize, 0x08, 0x8E);
+		idt_set_gate(40, irq8  as usize, 0x08, 0x8E);
+		idt_set_gate(41, irq9  as usize, 0x08, 0x8E);
+		idt_set_gate(42, irq10 as usize, 0x08, 0x8E);
+		idt_set_gate(43, irq11 as usize, 0x08, 0x8E);
+		idt_set_gate(44, irq12 as usize, 0x08, 0x8E);
+		idt_set_gate(45, irq13 as usize, 0x08, 0x8E);
+		idt_set_gate(46, irq14 as usize, 0x08, 0x8E);
+		idt_set_gate(47, irq15 as usize, 0x08, 0x8E);
 
-		idt_flush(&idt_ptr as *const IDTPointer as u32);
+		idt_flush(&idt_ptr as *const IDTPointer as usize);
 	}
 }
 
-unsafe fn idt_set_gate(n: uint, base: u32, sel: u16, flags: u8)
+unsafe fn idt_set_gate(n: usize, base: usize, sel: u16, flags: u8)
 {
 	idt_entries[n].base_low = (base & 0xFFFF) as u16;
 	idt_entries[n].base_high = ((base >> 16) & 0xFFFF) as u16;
@@ -101,7 +101,7 @@ unsafe fn idt_set_gate(n: uint, base: u32, sel: u16, flags: u8)
 
 extern
 {
-	fn idt_flush(pointer: u32);
+	fn idt_flush(pointer: usize);
 	fn isr0 ();
 	fn isr1 ();
 	fn isr2 ();

--- a/arch/x86/cpu/pic.rs
+++ b/arch/x86/cpu/pic.rs
@@ -43,7 +43,7 @@ pub fn remap_pic(offset: u8)
 	}
 }
 
-pub fn enable_irq(irq: uint)
+pub fn enable_irq(irq: u32)
 {
 	let (port, line) = if irq < 8
 	{
@@ -61,7 +61,7 @@ pub fn enable_irq(irq: uint)
 	}
 }
 
-pub fn disable_irq(irq: uint)
+pub fn disable_irq(irq: u32)
 {
 	let (port, line) = if irq < 8
 	{

--- a/arch/x86/cpu/timer.rs
+++ b/arch/x86/cpu/timer.rs
@@ -3,7 +3,7 @@ use platform::io;
 static TIMER_COMMAND: u16 = 0x43;
 static TIMER_CHANNEL0: u16 = 0x40;
 
-pub fn set_interval(frequency: uint)
+pub fn set_interval(frequency: u32)
 {
 	let divisor = 1193180 / frequency;
 	let l = divisor as u8;

--- a/arch/x86/vga/mod.rs
+++ b/arch/x86/vga/mod.rs
@@ -22,10 +22,10 @@ pub enum Color {
 
 impl Copy for Color {}
 
-pub static ROWS: uint = 25;
-pub static COLS: uint = 80;
+pub static ROWS: u32 = 25;
+pub static COLS: u32 = 80;
 
-pub fn putc(xpos: uint, ypos: uint, value: u8)
+pub fn putc(xpos: u32, ypos: u32, value: u8)
 {
 	if xpos >= COLS || ypos >= ROWS { return }
 	unsafe
@@ -34,7 +34,7 @@ pub fn putc(xpos: uint, ypos: uint, value: u8)
 	}
 }
 
-pub fn setfg(xpos: uint, ypos: uint, value: Color)
+pub fn setfg(xpos: u32, ypos: u32, value: Color)
 {
 	if xpos >= COLS || ypos >= ROWS { return }
 	unsafe
@@ -44,7 +44,7 @@ pub fn setfg(xpos: uint, ypos: uint, value: Color)
 	}
 }
 
-pub fn setbg(xpos: uint, ypos: uint, value: Color)
+pub fn setbg(xpos: u32, ypos: u32, value: Color)
 {
 	if xpos >= COLS || ypos >= ROWS { return }
 	unsafe
@@ -54,7 +54,7 @@ pub fn setbg(xpos: uint, ypos: uint, value: Color)
 	}
 }
 
-pub fn move_cursor(xpos: uint, ypos: uint)
+pub fn move_cursor(xpos: u32, ypos: u32)
 {
 	if xpos >= COLS || ypos >= COLS { return };
 	let pos = ypos * COLS + xpos;

--- a/kernel/interrupts/keyboard.rs
+++ b/kernel/interrupts/keyboard.rs
@@ -2,7 +2,7 @@ use kernel::stdio::StdioWriter;
 use kernel::keyboard::*;
 use platform::vga::Color;
 
-static mut shift: uint = 0;
+static mut shift: u32 = 0;
 static mut irqprinter: StdioWriter = StdioWriter{ xpos: 0, ypos: 4, fg: Color::Yellow, bg: Color::LightRed };
 
 pub fn keyboard_irq()
@@ -19,7 +19,7 @@ pub fn keyboard_irq()
 			KeyboardKey::Return => { printer.crlf(); },
 			KeyboardKey::Shift => unsafe { shift += 1; },
 			KeyboardKey::Tab => { printer.tab(); },
-			KeyboardKey::Unknown(c) => { printer.print_hex(c as uint, 8); printer.print_char(' '); },
+			KeyboardKey::Unknown(c) => { printer.print_hex(c as u32, 8); printer.print_char(' '); },
 			_ => {},
 		},
 		_ => {},

--- a/kernel/interrupts/mod.rs
+++ b/kernel/interrupts/mod.rs
@@ -24,7 +24,7 @@ fn unknown_irq(interrupt_number: u32, error_code: u32)
 	printer.fg = Color::Black;
 	printer.bg = Color::White;
 	printer.go_to(10, 6);
-	printer.print_hex(interrupt_number as uint, 32);
+	printer.print_hex(interrupt_number as u32, 32);
 	printer.go_to(10, 7);
-	printer.print_bin(error_code as uint, 32);
+	printer.print_bin(error_code as u32, 32);
 }

--- a/kernel/interrupts/timer.rs
+++ b/kernel/interrupts/timer.rs
@@ -1,7 +1,7 @@
 use kernel::stdio::StdioWriter;
 use platform::vga::Color;
 
-static mut tick: uint = 48;
+static mut tick: u32 = 48;
 
 pub fn handle_irq()
 {

--- a/kernel/main.rs
+++ b/kernel/main.rs
@@ -24,7 +24,7 @@ fn main()
 }
 
 #[lang = "panic_fmt"]
-extern fn panic_fmt(args: ::core::fmt::Arguments, file: &str, line: uint) -> !
+extern fn panic_fmt(args: ::core::fmt::Arguments, file: &str, line: u32) -> !
 {
 	let mut printer = StdioWriter::new();
 	printer.bg = Color::Black;

--- a/kernel/stdio.rs
+++ b/kernel/stdio.rs
@@ -5,8 +5,8 @@ use platform::vga;
 
 pub struct StdioWriter
 {
-	pub xpos: uint,
-	pub ypos: uint,
+	pub xpos: u32,
+	pub ypos: u32,
 	pub fg: Color,
 	pub bg: Color
 }
@@ -28,9 +28,9 @@ impl StdioWriter
 
 	pub fn clear_screen(&mut self)
 	{
-		for y in range(0u, ROWS)
+		for y in range(0u32, ROWS)
 		{
-			for x in range(0u, COLS)
+			for x in range(0u32, COLS)
 			{
 				vga::putc(x, y, 0);
 				vga::setfg(x, y, self.fg);
@@ -40,7 +40,7 @@ impl StdioWriter
 		self.go_to(0, 0);
 	}
 
-	pub fn go_to(&mut self, x: uint, y: uint)
+	pub fn go_to(&mut self, x: u32, y: u32)
 	{
 		self.move_coords(x, y);
 		self.set_cursor();
@@ -97,7 +97,7 @@ impl StdioWriter
 		}
 	}
 
-	fn move_coords(&mut self, x: uint, y: uint)
+	fn move_coords(&mut self, x: u32, y: u32)
 	{
 		let mut newx = x;
 		let mut newy = y;
@@ -112,7 +112,7 @@ impl StdioWriter
 		vga::move_cursor(self.xpos, self.ypos);
 	}
 
-	pub fn print_dec(&mut self, v: uint)
+	pub fn print_dec(&mut self, v: u32)
 	{
 		if v == 0
 		{
@@ -136,13 +136,13 @@ impl StdioWriter
 		self.set_cursor();
 	}
 
-	pub fn print_bin(&mut self, v: uint, sz: uint)
+	pub fn print_bin(&mut self, v: u32, sz: u32)
 	{
 		self.print_screen("0b");
 
-		for i in range_step_inclusive(sz as int - 1, 0, -1)
+		for i in range_step_inclusive(sz as i32 - 1, 0, -1)
 		{
-			let c = match (v >> (i as uint)) & 0x1
+			let c = match (v >> (i as u32)) & 0x1
 			{
 				0 => '0',
 				_ => '1',
@@ -153,16 +153,16 @@ impl StdioWriter
 		self.set_cursor();
 	}
 
-	pub fn print_hex(&mut self, v: uint, sz: uint)
+	pub fn print_hex(&mut self, v: u32, sz: u32)
 	{
 		self.print_screen("0x");
 
-		for i in range_step_inclusive(sz as int - 4, 0i, -4)
+		for i in range_step_inclusive(sz as i32 - 4, 0i32, -4)
 		{
-			let c = match (v >> (i as uint)) & 0xF
+			let c = match (v >> (i as u32)) & 0xF
 			{
-				c if c <= 9 => c + '0' as uint,
-				c => c + -10 + 'A' as uint,
+				c if c <= 9 => c + '0' as u32,
+				c => c + -10 + 'A' as u32,
 			} as u8;
 			self.raw_print_char(c);
 			self.go_right();


### PR DESCRIPTION
I updated the int types to match the new isize/usize convention.  `uint`s which were used as pointers are now usize, `int/uint`s which were not are now `i32/u32`.

Not an important change, but the code base is small enough that a blanket change like this is easy enough that I felt like it was worthwhile vs. leaving the `int`s in.
